### PR TITLE
feat: make init both interactive and args driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ brew install kubeshop/monokle/monokle-cli
 Monokle CLI exposes following commands:
 
 * `monokle validate [path]` - validate Kubernetes resources in a given path.
-* `monokle init` - use wizard to generate local policy configuration file.
+* `monokle init` - generate local configuration file.
 * `monokle login` - login to Monokle Cloud to use remote policy.
 * `monokle logout`- logout from Monokle Cloud.
 * `monokle whoami` - get information about currently authenticated user.

--- a/monokle.validation.yaml
+++ b/monokle.validation.yaml
@@ -13,4 +13,4 @@ rules:
   open-policy-agent/memory-request: "err"
 settings:
   kubernetes-schema:
-    schemaVersion: v1.24.2
+    schemaVersion: v1.26.8

--- a/src/commands/init.io.ts
+++ b/src/commands/init.io.ts
@@ -45,7 +45,3 @@ export const promptForOverwrite = async () => {
 export const success = (path: string) => `
 Successfully generated policy configuration file in ${C.bold(path)}.
 `;
-
-export const error = (err: string) => `
-Error generating policy configuration file: ${C.bold(err)}.
-`;

--- a/src/commands/init.io.ts
+++ b/src/commands/init.io.ts
@@ -5,8 +5,8 @@ export const promptForKubernetesVersion = async () => {
   const kubernetesVersionSelect = await prompts({
     type: 'text',
     name: 'value',
-    message: 'Add your Kubernetes version (e.g. v1.27.1)',
-    validate: (value: string) => value.length > 0 && value.trim().match(/v\d\.\d\d\.\d+/g) ? true : 'Please enter a valid Kubernetes version'
+    message: 'Add your Kubernetes version (e.g. 1.27.1)',
+    validate: (value: string) => value.length > 0 && value.trim().match(/v?\d\.\d\d\.\d+/g) ? true : 'Please enter a valid Kubernetes version'
   });
 
   return kubernetesVersionSelect.value;
@@ -22,12 +22,23 @@ export const promptForFrameworks = async () => {
       { title: 'Restricted Pod Security Standard', value: 'pss-restricted' },
       { title: 'Kubernetes Hardening Guidance by NSA & CISA', value: 'nsa' }
     ],
-    min: 1,
+    min: 0,
     max: 3,
     hint: '- Space to select. Return to submit.'
   });
 
   return frameworkSelect.value;
+};
+
+export const promptForOverwrite = async () => {
+  const overwriteSelect = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message: 'Overwrite existing config file?',
+    initial: false
+  });
+
+  return overwriteSelect.value;
 };
 
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,12 +1,12 @@
-import { readFile, writeFile } from "fs/promises";
+import { writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { resolve } from "path";
-import { Document, parseDocument } from "yaml";
+import { Document } from "yaml";
 import { Config, PluginMap, RuleMap } from "@monokle/validation";
 import { command } from "../utils/command.js";
 import { print } from "../utils/screens.js";
 import { isDefined } from "../utils/isDefined.js";
-import { promptForFrameworks, promptForKubernetesVersion, promptForOverwrite, success, error } from './init.io.js';
+import { promptForFrameworks, promptForKubernetesVersion, promptForOverwrite, success } from './init.io.js';
 import { Framework, getFrameworkConfig } from "../frameworks/index.js";
 import defaultConfig from "../utils/defaultConfig.js";
 
@@ -113,7 +113,7 @@ export const init = command<Options>({
 
       print(success(configPath));
     } catch (err: any) {
-      print(error(err.message));
+      throw `Error initializing config: ${err.message}}`;
     }
   },
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,57 +1,117 @@
-import { writeFile } from "fs/promises";
-import { Document } from "yaml";
+import { readFile, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { resolve } from "path";
+import { Document, parseDocument } from "yaml";
 import { Config, PluginMap, RuleMap } from "@monokle/validation";
 import { command } from "../utils/command.js";
 import { print } from "../utils/screens.js";
 import { isDefined } from "../utils/isDefined.js";
-import { promptForFrameworks, promptForKubernetesVersion, success, error } from './init.io.js';
+import { promptForFrameworks, promptForKubernetesVersion, promptForOverwrite, success, error } from './init.io.js';
 import { Framework, getFrameworkConfig } from "../frameworks/index.js";
-import { resolve } from "path";
+import defaultConfig from "../utils/defaultConfig.js";
 
-type Options = {};
+type Options = {
+  version?: string;
+  framework?: Framework;
+  overwrite?: boolean;
+};
 
 export const init = command<Options>({
   command: "init",
   describe: "Generate a Monokle policy config file for your project.",
-  async handler() {
+  builder(args) {
+    return args
+      .option("schema-version", {
+        type: "string",
+        description: "Kubernetes version to use.",
+        alias: "v",
+      })
+      .option("framework", {
+        type: "string",
+        choices: ["pss-restricted", "pss-baseline", "nsa"] as const,
+        description: "Validation framework to use.",
+        alias: "f",
+      })
+      .option("overwrite", {
+        type: "boolean",
+        description: "Overwrite existing config file.",
+        default: false,
+        alias: "o",
+      });
+  },
+  async handler({ schemaVersion, framework, overwrite }) {
+    const interactive = !isDefined(schemaVersion) && !isDefined(framework) && isDefined(overwrite);
+    const configPath = resolve(process.cwd(), 'monokle.validation.yaml');
+    const hasConfig = existsSync(configPath);
+
+    if (hasConfig && !interactive && !overwrite) {
+      throw `Config file already exists in ${configPath}. Use --overwrite flag to overwrite it.`
+    }
+
     try {
-      const kubernetesVersion = await promptForKubernetesVersion();
+      let kubernetesVersion = schemaVersion;
+      let frameworks = framework ? [framework] : [];
 
-      if (!isDefined(kubernetesVersion)) {
-        return;
-      }
+      if (interactive) {
+        kubernetesVersion = await promptForKubernetesVersion();
 
-      const frameworks = await promptForFrameworks();
+        if (!isDefined(kubernetesVersion)) {
+          return;
+        }
 
-      if (!isDefined(frameworks)) {
-        return;
-      }
+        frameworks = await promptForFrameworks();
 
-      const configs: Config[] = await Promise.all(frameworks.map(async (framework: Framework) => {
-        return getFrameworkConfig(framework);
-      }));
+        if (!isDefined(frameworks)) {
+          return;
+        }
 
-      const fullConfig: Config = {
-        plugins: configs.reduce<PluginMap>((acc, config) => {
-          return {
-            ...acc,
-            ...config.plugins
+        if (hasConfig) {
+          const canOverwrite = await promptForOverwrite();
+
+          if (!canOverwrite) {
+            return;
           }
-        }, {}),
-        rules: mergeRules(configs.map(config => config.rules).filter(isDefined)),
-        settings: {
+        }
+      }
+
+      const config: Config = {};
+      if (frameworks.length > 0) {
+        const configs: Config[] = (await Promise.all(frameworks.map(async (framework: Framework) => {
+          return getFrameworkConfig(framework);
+        }))).filter(isDefined);
+
+        const fullConfig: Config = {
+          plugins: configs.reduce<PluginMap>((acc, config) => {
+            return {
+              ...acc,
+              ...config.plugins
+            }
+          }, {}),
+          rules: mergeRules(configs.map(config => config.rules).filter(isDefined)),
+        };
+
+        config.plugins = fullConfig.plugins;
+        config.rules = fullConfig.rules;
+      } else {
+        const defaultConfigJson = defaultConfig as Config;
+        config.plugins = defaultConfigJson.plugins;
+        config.rules = defaultConfigJson.rules;
+        config.settings = defaultConfigJson.settings;
+      }
+
+      if (isDefined(kubernetesVersion)) {
+        config.settings = {
           "kubernetes-schema": {
-            schemaVersion: kubernetesVersion,
+            schemaVersion: `v${kubernetesVersion}`.replace(/v+/g, 'v'),
           },
-        },
-      };
+        };
+      }
 
       const configYaml = new Document();
-      (configYaml.contents as any) = fullConfig;
-      await writeFile(resolve('monokle.validation.yaml'), configYaml.toString())
+      (configYaml.contents as any) = config;
+      await writeFile(configPath, configYaml.toString())
 
-      print(success(resolve('monokle.validation.yaml')));
-
+      print(success(configPath));
     } catch (err: any) {
       print(error(err.message));
     }

--- a/src/frameworks/pss-baseline.ts
+++ b/src/frameworks/pss-baseline.ts
@@ -20,7 +20,7 @@ export default {
   },
   settings: {
     "kubernetes-schema": {
-      schemaVersion: "v1.25.0",
+      schemaVersion: "v1.26.8",
     },
   },
 };

--- a/src/frameworks/pss-restricted.ts
+++ b/src/frameworks/pss-restricted.ts
@@ -26,7 +26,7 @@ export default {
   },
   settings: {
     "kubernetes-schema": {
-      schemaVersion: "v1.25.0",
+      schemaVersion: "v1.26.8",
     },
   },
 };

--- a/src/utils/defaultConfig.ts
+++ b/src/utils/defaultConfig.ts
@@ -1,0 +1,22 @@
+export default {
+  plugins: {
+    'yaml-syntax': true,
+    'open-policy-agent': true,
+    'resource-links': true,
+    'kubernetes-schema': true,
+    annotations: true
+  },
+  rules: {
+    'yaml-syntax/no-bad-alias': 'warn',
+    'yaml-syntax/no-bad-directive': false,
+    'open-policy-agent/no-last-image': 'err',
+    'open-policy-agent/cpu-limit': 'err',
+    'open-policy-agent/memory-limit': 'err',
+    'open-policy-agent/memory-request': 'err'
+  },
+  settings: {
+    "kubernetes-schema": {
+      schemaVersion: "v1.24.2",
+    },
+  },
+};

--- a/src/utils/defaultConfig.ts
+++ b/src/utils/defaultConfig.ts
@@ -16,7 +16,7 @@ export default {
   },
   settings: {
     "kubernetes-schema": {
-      schemaVersion: "v1.24.2",
+      schemaVersion: "v1.26.8",
     },
   },
 };

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -31,7 +31,7 @@ describe('Config command', (runCommand) => {
     expect(result.err).toBe(null);
     expect(result.output).toContain('local policy from');
     expect(result.output).toContain('/monokle.validation.yaml');
-    expect(result.output).toContain('schemaVersion: v1.24.2');
+    expect(result.output).toContain('schemaVersion: v1.26.8');
   });
 
   it('shows info about remote config', async () => {

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -12,7 +12,7 @@ describe('Validate command', (runCommand) => {
     const result = await runCommand('validate ./test/assets/single-bad-resource.yaml');
 
     expect(result.err).toBe('Validation failed with 3 errors');
-    expect(result.output).toContain('12 misconfigurations found. (3 errors)');
+    expect(result.output).toContain('11 misconfigurations found. (3 errors)');
     expect(result.output).toContain('test/assets/single-bad-resource.yaml');
   });
 
@@ -20,7 +20,7 @@ describe('Validate command', (runCommand) => {
     const result = await runCommand('validate ./test/assets');
 
     expect(result.err).toBe('Validation failed with 6 errors');
-    expect(result.output).toContain('26 misconfigurations found. (6 errors)');
+    expect(result.output).toContain('23 misconfigurations found. (6 errors)');
     expect(result.output).toContain('test/assets/multiple-bad-resources.yaml');
     expect(result.output).toContain('test/assets/single-bad-resource.yaml');
   });


### PR DESCRIPTION
This PR improves `init` command. See #4.

![monokle 20230905](https://github.com/kubeshop/monokle-cli/assets/1061942/9116eca8-c905-4661-9cb8-d6588b3b51d4)

## Changes

- Rework `init` command to be both interactive and args driven.
    - It's interactive when no args are passed.
    - Args driven if any arg is passed.
- Introduced args:
    - `--framework` (`-f`)
    - `--schema-version` (`-v`) (since `version` is reserved keyword)
    - `--overwrite` (`-o`)

## Fixes

- Kubernetes version can be now passed with and without `v` to version prompt.
- Framework is not required by prompt/wizard now (without it, default configuration will be used).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
