### PR TITLE
Improve config precedence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@monokle/parser": "0.1.0",
-        "@monokle/synchronizer": "0.6.0",
+        "@monokle/synchronizer": "0.7.0",
         "@monokle/validation": "0.25.4",
         "abortcontroller-polyfill": "1.7.5",
         "boxen": "7.0.0",
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.6.0.tgz",
-      "integrity": "sha512-CoFzrikvXUOa2PEzsoegERHN1OZ+mNzXfup1FJvNG59VvWTJ2pFZNppfzM2pJMmp07FiHqads2T4yFOWn5Cl9A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.7.0.tgz",
+      "integrity": "sha512-x1VltT0dpfWdb5F7AS5BuLAoENccudoJBfWzwzSBZBzNEnp+u48AfxEcy26mvCGn5P+iQdsgo7AR36PYni6qDA==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",
@@ -6335,9 +6335,9 @@
       }
     },
     "@monokle/synchronizer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.6.0.tgz",
-      "integrity": "sha512-CoFzrikvXUOa2PEzsoegERHN1OZ+mNzXfup1FJvNG59VvWTJ2pFZNppfzM2pJMmp07FiHqads2T4yFOWn5Cl9A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.7.0.tgz",
+      "integrity": "sha512-x1VltT0dpfWdb5F7AS5BuLAoENccudoJBfWzwzSBZBzNEnp+u48AfxEcy26mvCGn5P+iQdsgo7AR36PYni6qDA==",
       "requires": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@monokle/parser": "0.1.0",
-    "@monokle/synchronizer": "0.6.0",
+    "@monokle/synchronizer": "0.7.0",
     "@monokle/validation": "0.25.4",
     "abortcontroller-polyfill": "1.7.5",
     "boxen": "7.0.0",

--- a/src/commands/config.io.ts
+++ b/src/commands/config.io.ts
@@ -1,19 +1,35 @@
+import { Config } from "@monokle/validation";
 import { C, Screen } from "../utils/screens.js";
 import { ConfigData } from "../utils/config.js";
 import { Document } from "yaml";
 
-export const configInfo = (configData: ConfigData, targetPath: string) => {
+const isConfigData = (configData: any) => {
+  return configData && typeof configData === 'object' && configData.config;
+}
+
+export const configInfo = (configInput: ConfigData | Config, targetPath: string) => {
   let configInfo = '';
-  if (configData.isFrameworkBased) {
-    configInfo = `${C.bold(configData.framework)} framework based policy`;
-  } else if (configData.isRemote) {
-    configInfo = `remote policy from ${C.bold(configData.remoteParentProject?.name ?? 'unknown')} project`;
+  let configContent: Config = {};
+
+  if (!isConfigData(configInput)) {
+    configInfo = 'default policy';
+    configContent = configInput as Config;
   } else {
-    configInfo = `local policy from ${C.bold(configData.path)} file`;
+    const configData = configInput as ConfigData;
+
+    configContent = configData.config ?? {};
+
+    if (configData.isFrameworkBased) {
+      configInfo = `${C.bold(configData.framework)} framework based policy`;
+    } else if (configData.isRemote) {
+      configInfo = `remote policy from ${C.bold(configData.remoteParentProject?.name ?? 'unknown')} project`;
+    } else {
+      configInfo = `local policy from ${C.bold(configData.path)} file`;
+    }
   }
 
   const configYaml = new Document();
-  (configYaml.contents as any) = configData.config;
+  (configYaml.contents as any) = configContent || {};
 
   const screen = new Screen();
 
@@ -24,8 +40,8 @@ export const configInfo = (configData: ConfigData, targetPath: string) => {
   return screen.toString();
 };
 
-export const configYaml = (configData: ConfigData) => {
+export const configYaml = (configData: Config) => {
   const configYaml = new Document();
-  (configYaml.contents as any) = configData.config;
+  (configYaml.contents as any) = configData ?? {};
   return configYaml.toString();
 }

--- a/src/commands/config.io.ts
+++ b/src/commands/config.io.ts
@@ -3,22 +3,12 @@ import { C, Screen } from "../utils/screens.js";
 import { ConfigData } from "../utils/config.js";
 import { Document } from "yaml";
 
-const isConfigData = (configData: any) => {
-  return configData && typeof configData === 'object' && configData.config;
-}
-
-export const configInfo = (configInput: ConfigData | Config, targetPath: string) => {
+export const configInfo = (configData: ConfigData, configContent: Config, targetPath: string) => {
   let configInfo = '';
-  let configContent: Config = {};
 
-  if (!isConfigData(configInput)) {
+  if (!configData?.config) {
     configInfo = 'default policy';
-    configContent = configInput as Config;
   } else {
-    const configData = configInput as ConfigData;
-
-    configContent = configData.config ?? {};
-
     if (configData.isFrameworkBased) {
       configInfo = `${C.bold(configData.framework)} framework based policy`;
     } else if (configData.isRemote) {
@@ -29,7 +19,7 @@ export const configInfo = (configInput: ConfigData | Config, targetPath: string)
   }
 
   const configYaml = new Document();
-  (configYaml.contents as any) = configContent || {};
+  (configYaml.contents as any) = configContent;
 
   const screen = new Screen();
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -53,7 +53,7 @@ export const config = command<Options>({
     const usedConfig = await getConfig(path, configPath, project, framework, { isDefaultConfigPath, apiToken });
 
     let configContent = usedConfig?.config ?? {};
-    if (!usedConfig) {
+    if (!usedConfig?.config) {
       const parser = new ResourceParser();
       const validator = createExtensibleMonokleValidator(parser);
       await validator.preload();
@@ -61,7 +61,7 @@ export const config = command<Options>({
     }
 
     if (output === "pretty") {
-      print(configInfo(usedConfig ?? configContent, path));
+      print(configInfo(usedConfig, configContent, path));
     } else if (output === "json") {
       print(JSON.stringify(configContent, null, 2));
     } else if (output === "yaml") {

--- a/src/commands/validate.io.ts
+++ b/src/commands/validate.io.ts
@@ -89,9 +89,9 @@ export const failure = (response: ValidationResponse) => {
   return screen.toString();
 };
 
-export const configInfo = (configData: ConfigData | null) => {
+export const configInfo = (configData: ConfigData) => {
   let configInfo = '';
-  if (!configData) {
+  if (!configData?.config) {
     configInfo = 'default policy';
   } else if (configData.isFrameworkBased) {
     configInfo = `${C.bold(configData.framework)} framework based policy`;

--- a/src/commands/validate.io.ts
+++ b/src/commands/validate.io.ts
@@ -89,9 +89,11 @@ export const failure = (response: ValidationResponse) => {
   return screen.toString();
 };
 
-export const configInfo = (configData: ConfigData) => {
+export const configInfo = (configData: ConfigData | null) => {
   let configInfo = '';
-  if (configData.isFrameworkBased) {
+  if (!configData) {
+    configInfo = 'default policy';
+  } else if (configData.isFrameworkBased) {
     configInfo = `${C.bold(configData.framework)} framework based policy`;
   } else if (configData.isRemote) {
     configInfo = `remote policy from ${C.bold(configData.remoteParentProject?.name ?? 'unknown')} project. It can be adjusted on ${configData.remoteParentProject?.remoteUrl}`;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -71,7 +71,7 @@ export function describe(name: string, fn: (runCommand: RunCommandFn) => void) {
   });
 }
 
-export function getRemoteLikeEnvStubber() {
+export function getRemoteLikeEnvStubber(throwsOnSynchronize = false) {
   const authenticator = authenticatorGetter.authenticator;
   const synchronizer = synchronizerGetter.synchronizer;
 
@@ -85,15 +85,21 @@ export function getRemoteLikeEnvStubber() {
       token: 'test-token',
     };
 
-    const synchronizeStub = sinon.stub(synchronizer, 'synchronize').resolves({
-      valid: true,
-      path: 'some/fake/path',
-      policy: {
-        plugins: {
-          'yaml-syntax': true,
-          'open-policy-agent': true
-        }
+    const synchronizeStub = sinon.stub(synchronizer, 'synchronize').callsFake(async () => {
+      if (throwsOnSynchronize) {
+        throw new Error('Error when synchronizing policy...');
       }
+
+      return {
+        valid: true,
+        path: 'some/fake/path',
+        policy: {
+          plugins: {
+            'yaml-syntax': true,
+            'open-policy-agent': true
+          }
+        }
+      };
     });
     stubs.push(synchronizeStub);
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -82,6 +82,7 @@ export function getRemoteLikeEnvStubber() {
     (authenticatorGetter.authenticator as any)._user = {
       email: 'testuser@kubeshop.io',
       isAuthenticated: true,
+      token: 'test-token',
     };
 
     const synchronizeStub = sinon.stub(synchronizer, 'synchronize').resolves({

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -54,7 +54,69 @@ describe('Validate command', (runCommand) => {
     const result = await runCommand('validate ./test/assets/single-bad-resource.yaml');
 
     expect(result.err).toBe(null);
+    expect(result.output).toContain('Validating using remote policy');
     expect(result.output).toContain('11 misconfigurations found. (0 errors)');
     expect(result.output).toContain('test/assets/single-bad-resource.yaml');
+  });
+
+  it('can validate resources with remote config with -p flag', async () => {
+    stubber = getRemoteLikeEnvStubber();
+    stubber.stub();
+
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -p test-project');
+
+    expect(result.err).toBe(null);
+    expect(result.output).toContain('Validating using remote policy');
+    expect(result.output).toContain('11 misconfigurations found. (0 errors)');
+    expect(result.output).toContain('test/assets/single-bad-resource.yaml');
+  });
+
+  it('can validate resources with remote or local config when -p and -c flags passed (remote)', async () => {
+    stubber = getRemoteLikeEnvStubber();
+    stubber.stub();
+
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml --project test-project --config ./monokle.full-validation.yaml');
+
+    expect(result.err).toBe(null);
+    expect(result.output).toContain('Validating using remote policy');
+    expect(result.output).toContain('11 misconfigurations found. (0 errors)');
+    expect(result.output).toContain('test/assets/single-bad-resource.yaml');
+  });
+
+  it('can validate resources with remote or local config when -p and -c flags passed (local)', async () => {
+    stubber = getRemoteLikeEnvStubber(true);
+    stubber.stub();
+
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -p test-project -c ./monokle.full-validation.yaml');
+
+    expect(result.err).toBe(null);
+    expect(result.output).toContain('Validating using local policy');
+    expect(result.output).toContain('12 misconfigurations found. (0 errors)');
+    expect(result.output).toContain('test/assets/single-bad-resource.yaml');
+  });
+
+  it('throws on -p and no project', async () => {
+    stubber = getRemoteLikeEnvStubber(true);
+    stubber.stub();
+
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -p non-existent');
+
+    expect(result.err.message).toContain('Error when synchronizing policy');
+  });
+
+  it('throws on -c and no file', async () => {
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -c non-existent.yaml');
+
+    expect(result.err.message).toContain('Config file non-existent.yaml not found');
+  });
+
+
+  it('throws on -p -c and no project and file', async () => {
+    stubber = getRemoteLikeEnvStubber(true);
+    stubber.stub();
+
+    const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -p test-project -c non-existent.yaml');
+
+    expect(result.err.message).toContain('Error when reading policy');
   });
 });


### PR DESCRIPTION
This PR fixes #16 and fixes #13.

## Changes

- Adjusted config precedence as described in #16.
- Introduced `--project` (`-p`) flag to explicitly define remote project to use policy from (fixes #13).

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
