### PR TITLE
fix: improve 'whoami' output

### DIFF
--- a/src/commands/whoami.io.ts
+++ b/src/commands/whoami.io.ts
@@ -3,3 +3,7 @@ import { C } from "../utils/screens.js";
 export const success = (user: string) => `
 Logged in as ${C.bold(user)}.
 `;
+
+export const error = `
+You are not signed into Monokle Cloud - use ${C.bold('monokle login')} to sign in or create an account on https://app.monokle.com.
+`;

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,8 +1,8 @@
 import { authenticatorGetter } from "../utils/authenticator.js";
-import { success } from "./whoami.io.js";
+import { error, success } from "./whoami.io.js";
 import { command } from "../utils/command.js";
 import { print } from "../utils/screens.js";
-import { throwIfNotAuthenticated } from "../utils/conditions.js";
+import { isAuthenticated } from "../utils/conditions.js";
 
 type Options = {};
 
@@ -10,9 +10,11 @@ export const whoami = command<Options>({
   command: "whoami",
   describe: "Get info about current user",
   async handler() {
-    throwIfNotAuthenticated();
-
-    const authenticator = authenticatorGetter.authenticator;
-    print(success(authenticator.user.email!));
+    if (!isAuthenticated()) {
+      print(error);
+    } else {
+      const authenticator = authenticatorGetter.authenticator;
+      print(success(authenticator.user.email!));
+    }
   },
 });

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -1,17 +1,17 @@
 import { authenticatorGetter } from "./authenticator.js";
 
-export function throwIfNotAuthenticated() {
-  const authenticator = authenticatorGetter.authenticator;
+export function isAuthenticated() {
+  return authenticatorGetter.authenticator.user.isAuthenticated;
+}
 
-  if (!authenticator.user.isAuthenticated) {
+export function throwIfNotAuthenticated() {
+  if (!isAuthenticated()) {
     throw new Error("Not authenticated.");
   }
 }
 
 export function throwIfAuthenticated() {
-  const authenticator = authenticatorGetter.authenticator;
-
-  if (authenticator.user.isAuthenticated) {
+  if (isAuthenticated()) {
     throw new Error("Already authenticated.");
   }
 }

--- a/test/whoami.spec.ts
+++ b/test/whoami.spec.ts
@@ -19,10 +19,10 @@ describe('Whoami command', (runCommand) => {
     expect(result.output).toContain('testuser@kubeshop.io');
   });
 
-  it('throws error when not authenticated', async () => {
+  it('show message when not authenticated', async () => {
     const result = await runCommand('whoami');
 
-    expect(result.err).not.toBe(null);
-    expect(result.err.message).toContain('Not authenticated');
+    expect(result.err).toBe(null);
+    expect(result.output).toContain('You are not signed into Monokle Cloud');
   });
 });


### PR DESCRIPTION
This PR improves `whoami` output.

## Changes

- Return nice message instead of throwing error when `whoami` run and user not authenticated.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
