### PR TITLE
fix: bump '@monokle/parser' dep to omit Helm files during parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@monokle/parser": "0.1.1",
+        "@monokle/parser": "0.2.0",
         "@monokle/synchronizer": "0.8.0",
         "@monokle/types": "0.2.1",
         "@monokle/validation": "0.28.2",
@@ -190,9 +190,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@monokle/parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@monokle/parser/-/parser-0.1.1.tgz",
-      "integrity": "sha512-QsZ4tNWcpupiiUrw2BB1AK+5810NjOg6XrFmmgAJOYIOy3jK6l5WFUWEEKxsyO0nz//wjgM+jEICXCdaPC6zhA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@monokle/parser/-/parser-0.2.0.tgz",
+      "integrity": "sha512-gcCWcfOUqTubwi9mJlrOb4X5NW5B6N4/lCR7oIh5pDL75rQUfuHbSbx+BkymZnrGgNNwGX9LMGukdW8A9Y5TMQ==",
       "dependencies": {
         "lodash": "4.17.21",
         "path-browserify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "vitest": "^0.34.3"
   },
   "dependencies": {
-    "@monokle/parser": "0.1.1",
+    "@monokle/parser": "0.2.0",
     "@monokle/synchronizer": "0.8.0",
     "@monokle/types": "0.2.1",
     "@monokle/validation": "0.28.2",


### PR DESCRIPTION
This PR fixes #24.

## Changes

- None.

## Fixes

- Bumped '@monokle/parser' dep to omit Helm files during parsing.

## Checklist

- [x] tested locally (needed to manually replace globally installed package content with local build due to https://github.com/kubeshop/monokle-cli/issues/24#issuecomment-1723588898)
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
