### PR TITLE
Improve cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+.idea/**
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,12 +6,14 @@ import { logout } from "./commands/logout.js";
 import { whoami } from "./commands/whoami.js";
 import { config } from "./commands/config.js";
 import { init } from "./commands/init.js";
+import {handleFailure} from "./errors.js";
 import fetch from "isomorphic-fetch";
 
 (global as any).fetch = fetch;
 import "abortcontroller-polyfill/dist/polyfill-patch-fetch.js";
 
-export const cli = yargs(hideBin(process.argv))
+const argv = hideBin(process.argv);
+export const cli = yargs(argv)
   .scriptName("monokle")
   .parserConfiguration({
     "greedy-arrays": false,
@@ -22,11 +24,15 @@ export const cli = yargs(hideBin(process.argv))
   .command(whoami)
   .command(config)
   .command(init)
-  .command('$0', 'Show getting started information', () => {}, (argv) => {
+  .command('$0', false, () => {}, () => {
     console.log("Missing or unknown command, try --help to see available commands or use\n\n" +
       " monokle validate .       Validate resources in your current folder using default validation rules.\n" +
       " monokle init             Generate a default configuration file.\n\n" +
       "Learn more at https://github.com/kubeshop/monokle-cli");
+  })
+  .fail((_, err) => {
+      const debug = argv.includes("--debug");
+      handleFailure(err, debug);
   })
   .showHelpOnFail(false)
   .wrap(100);

--- a/src/commands/config.io.ts
+++ b/src/commands/config.io.ts
@@ -27,7 +27,7 @@ export const configInfo = (configData: ConfigData, configContent: Config, target
 
   const screen = new Screen();
 
-  screen.line(`For ${targetPath} path, ${configInfo} will be used:`);
+  screen.line(`For ${targetPath === "." ? "current directory" : targetPath} path, ${configInfo} will be used:`);
   screen.line();
   screen.line(configYaml);
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,7 +7,6 @@ import { configInfo, configYaml, error } from "./config.io.js";
 import { assertApiFlags } from "../utils/flags.js";
 
 type Options = {
-  action: string;
   path: string;
   output: "pretty" | "json" | "yaml";
   config?: string;
@@ -17,7 +16,7 @@ type Options = {
 };
 
 export const config = command<Options>({
-  command: "config [action] [path]",
+  command: "config [path]",
   describe: "Show current config",
   builder(args) {
     return args
@@ -45,16 +44,13 @@ export const config = command<Options>({
         description: "Monokle Cloud API token to fetch remote policy. It will be used instead of authenticated user credentials.",
         alias: "t",
       })
-      .positional("action", { choices: ["show"], demandOption: true })
-      .positional("path", { type: "string", demandOption: true });
+      .positional("path", {
+        type: "string",
+        default: "."
+      });
   },
-  async handler({ _action, path, output, config, project, framework, apiToken }) {
-    try {
-      assertApiFlags(apiToken, project);
-    } catch (err: any) {
-      print(error(err.message));
-      return;
-    }
+  async handler({ path, output, config, project, framework, apiToken }) {
+    assertApiFlags(apiToken, project);
 
     const configPath = config ?? 'monokle.validation.yaml';
     const isDefaultConfigPath = config === undefined;

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -4,7 +4,7 @@ import { print } from "../utils/screens.js";
 import { Framework } from "../frameworks/index.js";
 import { getConfig } from "../utils/config.js";
 import { configInfo, configYaml, error } from "./config.io.js";
-import { verifyApiFlags } from "../utils/flags.js";
+import { assertApiFlags } from "../utils/flags.js";
 
 type Options = {
   action: string;
@@ -50,7 +50,7 @@ export const config = command<Options>({
   },
   async handler({ _action, path, output, config, project, framework, apiToken }) {
     try {
-      verifyApiFlags(apiToken, project);
+      assertApiFlags(apiToken, project);
     } catch (err: any) {
       print(error(err.message));
       return;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,6 +9,7 @@ import { isDefined } from "../utils/isDefined.js";
 import { promptForFrameworks, promptForKubernetesVersion, promptForOverwrite, success } from './init.io.js';
 import { Framework, getFrameworkConfig } from "../frameworks/index.js";
 import defaultConfig from "../utils/defaultConfig.js";
+import {FailedPrecondition} from "../errors.js";
 
 type Options = {
   version?: string;
@@ -45,7 +46,7 @@ export const init = command<Options>({
     const hasConfig = existsSync(configPath);
 
     if (hasConfig && !interactive && !overwrite) {
-      throw `Config file already exists in ${configPath}. Use --overwrite flag to overwrite it.`
+      throw new FailedPrecondition(`Config file already exists in ${configPath}. Use --overwrite flag to force this.`)
     }
 
     try {

--- a/src/commands/validate.io.ts
+++ b/src/commands/validate.io.ts
@@ -12,10 +12,6 @@ import { ValidationResponseBreakdown } from "../utils/getValidationResponseBreak
 
 export const success = () => `${S.success} All resources are valid.`;
 
-export const error = (err: string) => `
-Error running validate command: ${C.red(err)}.
-`;
-
 export const displayInventory = (allResources: Resource[]) => {
   const box = new Screen();
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,6 +16,7 @@ export class NotFound extends ExtendableError {
         super(identifier ? `No such ${object}, received '${identifier}'` : `No ${object} found`);
     }
 }
+export class FailedPrecondition extends ExtendableError {}
 
 export function handleFailure(err: unknown, debug: boolean) {
     if (!(err instanceof Error)) {
@@ -45,6 +46,10 @@ export function displayError(err: Error) {
         }
         case InvalidArgument.name: {
             print(failure(err.message));
+            return;
+        }
+        case FailedPrecondition.name: {
+            print(failure(err.message, "precondition"));
             return;
         }
         case NotFound.name: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,7 @@ export class NotFound extends ExtendableError {
     }
 }
 export class FailedPrecondition extends ExtendableError {}
+export class ValidationFailed extends ExtendableError {}
 
 export function handleFailure(err: unknown, debug: boolean) {
     if (!(err instanceof Error)) {
@@ -60,6 +61,9 @@ export function displayError(err: Error) {
                 print(warningInfo(err.message));
             }
             return;
+        }
+        case ValidationFailed.name: {
+            return; // We just want to exit with process.exit(1)
         }
         default: {
             print("Something unexpected happened, you can run with --debug for more details");

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,45 @@
+import {print} from "./utils/screens.js";
+import {authenticatorGetter} from "./utils/authenticator.js";
+
+export abstract class ExtendableError extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = new.target.name;
+    }
+}
+
+export class Unauthenticated extends ExtendableError {}
+export class AlreadyAuthenticated extends ExtendableError {}
+
+export function handleFailure(err: unknown, debug: boolean) {
+    if (!(err instanceof Error)) {
+        return;
+    }
+
+    displayError(err);
+
+    if (debug) {
+        console.log();
+        console.error(err)
+    }
+
+    process.exit(1)
+}
+
+export function displayError(err: Error) {
+    switch (err.name) {
+        case Unauthenticated.name: {
+            print("To get started with Monokle, please run: monokle login")
+            return;
+        }
+        case AlreadyAuthenticated.name: {
+            const authenticator = authenticatorGetter.authenticator;
+            print(`You are already authenticated as ${authenticator.user.email!}.`)
+            return;
+        }
+        default: {
+            print("Something unexpected happened, you can run with --debug for more details");
+            return;
+        }
+    }
+}

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -1,11 +1,23 @@
 import { Config } from "@monokle/validation";
+import pssBaseline from "./pss-baseline.js";
+import pssRestricted from "./pss-restricted.js";
+import nsa from "./nsa.js";
 
 export type Framework = "pss-restricted" | "pss-baseline" | "nsa";
 
 export const getFrameworkConfig = async (framework?: Framework): Promise<Config | undefined> => {
-  if (!framework) {
-    return undefined;
+  switch (framework) {
+    case "pss-baseline": {
+      return pssBaseline as Config;
+    }
+    case "pss-restricted": {
+      return pssRestricted as Config;
+    }
+    case "nsa": {
+      return nsa as Config;
+    }
+    default: {
+      return undefined;
+    }
   }
-  const { default: config } = await import(`./${framework}.js`);
-  return config;
 };

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -1,4 +1,5 @@
 import { authenticatorGetter } from "./authenticator.js";
+import {AlreadyAuthenticated, Unauthenticated} from "../errors.js";
 
 export function isAuthenticated() {
   return authenticatorGetter.authenticator.user.isAuthenticated;
@@ -6,12 +7,12 @@ export function isAuthenticated() {
 
 export function throwIfNotAuthenticated() {
   if (!isAuthenticated()) {
-    throw new Error("Not authenticated.");
+    throw new Unauthenticated();
   }
 }
 
 export function throwIfAuthenticated() {
   if (isAuthenticated()) {
-    throw new Error("Already authenticated.");
+    throw new AlreadyAuthenticated()
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -160,7 +160,6 @@ export async function getPolicyImplicit(path: string, configPath: string, token:
       const remoteConfig = await getRemotePolicyForPath(path, token);
       return remoteConfig;
     } catch (err) {
-      console.error(err);
       // Ignore error since we fallback to local config.
     }
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -34,7 +34,7 @@ export type ConfigData = {
  *
  * @param path Path to be validated.
  * @param configPath Path to config file.
- * @param project Monokle Cloud project slug to fetch config from.
+ * @param projectSlug Monokle Cloud project slug to fetch config from.
  * @param framework Framework to be used for validation.
  * @param options Additional options.
  * @returns Config data.

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -1,12 +1,14 @@
-export function verifyApiFlags(apiToken: string | undefined, projectSlug: string | undefined) {
+import {InvalidArgument} from "../errors.js";
+
+export function assertApiFlags(apiToken: string | undefined, projectSlug: string | undefined) {
   const isApiTokenValid = apiToken && apiToken.length > 0;
   const isProjectSlugValid = projectSlug && projectSlug.length > 0;
 
   if (isApiTokenValid && !isProjectSlugValid) {
-    throw new Error('Project slug (-p) is required when using an API token flag');
+    throw new InvalidArgument('Project slug (-p) is required when using an API token (-t) flag');
   }
 
   if (!isApiTokenValid && isProjectSlugValid) {
-    throw new Error('API token (-t) is required when using a project flag');
+    throw new InvalidArgument('API token (-t) is required when using a project (-p) flag');
   }
 }

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -12,5 +12,5 @@ export const S = logSymbols;
 export const C = chalk;
 export const B = boxen;
 
-export const failure = (msg: string) => `${C.bgRed(C.black(" failure "))} ${C.red(msg)}`;
+export const failure = (msg: string, name = "failure") => `${C.bgRed(C.black(name))} ${C.red(msg)}`;
 export const warningInfo = (msg: string) => `${C.bgYellow(C.black(" info "))} ${C.yellow(msg)}`;

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -5,7 +5,7 @@ import clearUpstream from "clear";
 import { Strands } from "strands";
 
 export const Screen = Strands;
-export const print = console.log;
+export const print = (msg: string) => console.log(msg);
 export const clear = clearUpstream;
 
 export const S = logSymbols;

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -11,3 +11,6 @@ export const clear = clearUpstream;
 export const S = logSymbols;
 export const C = chalk;
 export const B = boxen;
+
+export const failure = (msg: string) => `${C.bgRed(C.black(" failure "))} ${C.red(msg)}`;
+export const warningInfo = (msg: string) => `${C.bgYellow(C.black(" info "))} ${C.yellow(msg)}`;

--- a/test/login.spec.ts
+++ b/test/login.spec.ts
@@ -2,6 +2,7 @@ import { it, expect, afterEach } from 'vitest';
 import sinon from 'sinon';
 import { describe, getRemoteLikeEnvStubber } from './setup.js';
 import { authenticatorGetter } from '../src/utils/authenticator.js';
+import {AlreadyAuthenticated} from "../src/errors";
 
 describe('Login command', (runCommand) => {
   const stubs: sinon.SinonStub[] = [];
@@ -20,6 +21,6 @@ describe('Login command', (runCommand) => {
     const result = await runCommand('login');
 
     expect(result.err).not.toBe(null);
-    expect(result.err.message).toContain('Already authenticated');
+    expect(result.err instanceof AlreadyAuthenticated).toBeTruthy();
   });
 });

--- a/test/logout.spec.ts
+++ b/test/logout.spec.ts
@@ -1,5 +1,6 @@
 import { it, expect, afterEach } from 'vitest';
 import { describe, getRemoteLikeEnvStubber } from './setup.js';
+import {Unauthenticated} from "../src/errors";
 
 describe('Logout command', (runCommand) => {
   let stubber: ReturnType<typeof getRemoteLikeEnvStubber>;
@@ -22,6 +23,6 @@ describe('Logout command', (runCommand) => {
     const result = await runCommand('logout');
 
     expect(result.err).not.toBe(null);
-    expect(result.err.message).toContain('Not authenticated');
+    expect(result.err instanceof Unauthenticated).toBeTruthy();
   });
 });

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -1,5 +1,6 @@
 import { it, expect, afterEach } from 'vitest';
 import { describe, getRemoteLikeEnvStubber, getRemoteLikeApiKeyEnvStubber } from './setup.js';
+import {InvalidArgument, ValidationFailed} from "../src/errors.js";
 
 describe('Validate command', (runCommand) => {
   let stubber: ReturnType<typeof getRemoteLikeEnvStubber>;
@@ -11,14 +12,14 @@ describe('Validate command', (runCommand) => {
   it('can validate single resource file', async () => {
     const result = await runCommand('validate ./test/assets/single-bad-resource.yaml');
 
-    expect(result.err).toBe('Validation failed with 3 errors');
+    expect(result.err instanceof ValidationFailed).toBe(true);
     expect(result.output).toContain('12 misconfigurations found. (3 errors)');
     expect(result.output).toContain('test/assets/single-bad-resource.yaml');
   });
 
   it('can validate resources in a folder', async () => {
     const result = await runCommand('validate ./test/assets');
-    expect(result.err).toBe('Validation failed with 6 errors');
+    expect(result.err instanceof ValidationFailed).toBe(true);
     expect(result.output).toContain('26 misconfigurations found. (6 errors)');
     expect(result.output).toContain('test/assets/multiple-bad-resources.yaml');
     expect(result.output).toContain('test/assets/single-bad-resource.yaml');
@@ -97,15 +98,13 @@ describe('Validate command', (runCommand) => {
   it('warns on -p and no token flag', async () => {
     const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -p non-existent');
 
-    expect(result.err).toBe(null);
-    expect(result.output).toContain('API token (-t) is required');
+    expect(result.err instanceof InvalidArgument).toBe(true);
   });
 
   it('warns on -t and no project flag', async () => {
     const result = await runCommand('validate ./test/assets/single-bad-resource.yaml -t sample-token');
 
-    expect(result.err).toBe(null);
-    expect(result.output).toContain('Project slug (-p) is required');
+    expect(result.err instanceof InvalidArgument).toBe(true);
   });
 
   it('throws on -p -t and no project', async () => {


### PR DESCRIPTION
This PR improves error handling and fixes some bugs / unclear usage:

<img width="962" alt="Screenshot 2023-10-09 at 15 34 38" src="https://github.com/kubeshop/monokle-cli/assets/7761005/daf3ab9d-1e73-48e2-a3a1-d562aa3de5d7">

<img width="1078" alt="Screenshot 2023-10-09 at 15 54 17" src="https://github.com/kubeshop/monokle-cli/assets/7761005/c411e006-3e58-45fe-bbfd-ccf6128fcd98">


Some flags were also updated / introduced in `monokle validate` to better handle exit codes. This makes usages easier in automated environments.

- `--force` will return status code 0 even if there were warnings or errors.
- `--max-warnings` will return status code 1 if there the amount of warnings is higher than the maximum. This is useful for use cases where CI pipelines check that the amount of warnings always go down (can be a moving target).
