### PR TITLE
Improve error messages for Cloud integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@monokle/parser": "0.2.0",
-        "@monokle/synchronizer": "0.9.1",
-        "@monokle/types": "0.2.2",
-        "@monokle/validation": "0.30.0",
+        "@monokle/synchronizer": "0.10.2",
+        "@monokle/types": "0.3.1",
+        "@monokle/validation": "0.31.5",
         "abortcontroller-polyfill": "1.7.5",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.9.1.tgz",
-      "integrity": "sha512-FuiuiqO+vxrZd/qH6/uBNHXXgfCnukvonN18zvd7K/DEIPC7vqL5UceBafM7J4aa/JAxpUMnPPwLrAS2h8OM7Q==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.10.2.tgz",
+      "integrity": "sha512-l5xmz3RSq95RFPBBck/I0DzazDvi1PxICEu+8tZmCs/8a9dyWZ0+LuB4Js2xCpTFaSc30gbuCwIDM2FXKgWoPw==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",
@@ -233,23 +233,25 @@
       }
     },
     "node_modules/@monokle/types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@monokle/types/-/types-0.2.2.tgz",
-      "integrity": "sha512-GGhl30a1WImxfxWg9Ys7MY1VQi2NU2iCH+gf4kKGZxS6nqAkgU4G1kTTYnxQzGNoM4Zbabh5aRxINsckIV5a+g=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@monokle/types/-/types-0.3.1.tgz",
+      "integrity": "sha512-IkbVrLOXZ38TZUfCYDp8XVVskvsLYftFb7ZXSn3PlxtIVbBVUIexqSm5erJ5ZK400f6yACCK+4qGzkPAJ43FVw=="
     },
     "node_modules/@monokle/validation": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.30.0.tgz",
-      "integrity": "sha512-SwJFocU0nj7Du1HwI94b3gpzme2G+uKWZJu19k6UJ9GUxDEVP6onIJxj+cNYDreAOITdvdwn6siMRL1mEYOaqg==",
+      "version": "0.31.5",
+      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.5.tgz",
+      "integrity": "sha512-Mp9pzNLt8+EE/xYJb/YbJiRFmIUnhP9hkFdo+5XhhhkmiFN3BhQauFkgSaSj6W/pEBSCzo7rYLxToKdRDED0iQ==",
       "dependencies": {
         "@monokle/types": "*",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@rollup/plugin-virtual": "3.0.1",
         "ajv": "6.12.6",
         "change-case": "4.1.2",
+        "get-random-values": "^3.0.0",
         "isomorphic-fetch": "3.0.0",
         "lodash": "4.17.21",
         "node-fetch": "3.3.0",
+        "pako": "^2.1.0",
         "require-from-string": "2.0.2",
         "rollup": "3.18.0",
         "uuid": "9.0.0",
@@ -1562,6 +1564,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -2069,6 +2076,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-random-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-3.0.0.tgz",
+      "integrity": "sha512-mNznaBdYcpz7UAdnOtDGcLdNwAa79mXl5htEyyZ51YaeAWNf2g4x/2yCVBdNNTbi35wX0Stc2PJXM7G6rcONOA==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": "18 || >=20"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2148,6 +2166,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/globalthis": {
@@ -3005,6 +3032,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -3494,6 +3529,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -4009,6 +4049,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   },
   "dependencies": {
     "@monokle/parser": "0.2.0",
-    "@monokle/synchronizer": "0.9.1",
-    "@monokle/types": "0.2.2",
-    "@monokle/validation": "0.30.0",
+    "@monokle/synchronizer": "0.10.2",
+    "@monokle/types": "0.3.1",
+    "@monokle/validation": "0.31.5",
     "abortcontroller-polyfill": "1.7.5",
     "boxen": "7.0.0",
     "chalk": "5.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,8 +33,8 @@ export const cli = yargs(argv)
       "Learn more at https://github.com/kubeshop/monokle-cli");
   })
   .fail((_, err) => {
-      const debug = argv.includes("--debug");
-      handleFailure(err, debug, argv[0]);
+    const debug = argv.includes("--debug");
+    handleFailure(err, debug, argv);
   })
   .showHelpOnFail(false)
   .wrap(100);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ export const cli = yargs(argv)
   })
   .fail((_, err) => {
       const debug = argv.includes("--debug");
-      handleFailure(err, debug);
+      handleFailure(err, debug, argv[0]);
   })
   .showHelpOnFail(false)
   .wrap(100);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -66,18 +66,23 @@ export function displayError(err: Error, commandName?: string) {
             return; // We just want to exit with process.exit(1)
         }
         default: {
-            print(getFriendlyErrorMessage(err, commandName) ?? "Something unexpected happened, you can run with --debug for more details");
+            print(`${getFriendlyErrorMessage(err, commandName)} You can re-run with --debug for more details.`);
             return;
         }
     }
 }
 
-function getFriendlyErrorMessage(err: Error, commandName?: string): string | undefined {
+function getFriendlyErrorMessage(err: Error, commandName?: string): string {
     const errMsg = err.message.toLowerCase().trim();
 
-    if (errMsg.startsWith('not found') && (commandName === "validate" || commandName === "config")) {
-        return "Error communicating with Monokle Cloud. Seems like used project id may be invalid, please make sure it's correct.";
+    // Related to https://github.com/kubeshop/monokle-saas/issues/2173.
+    if (errMsg.includes('cannot read properties of null') && errMsg.includes('organizationid') && (commandName === "validate" || commandName === "config")) {
+        return 'Error communicating with Monokle Cloud. Please make sure you are using valid Automation Token.';
     }
 
-    return undefined;
+    if (errMsg.startsWith('not found') && (commandName === "validate" || commandName === "config")) {
+        return 'Error communicating with Monokle Cloud. Seems like used project id may be invalid, please make sure it is correct.';
+    }
+
+    return 'Something unexpected happened.';
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,12 +19,12 @@ export class NotFound extends ExtendableError {
 export class FailedPrecondition extends ExtendableError {}
 export class ValidationFailed extends ExtendableError {}
 
-export function handleFailure(err: unknown, debug: boolean) {
+export function handleFailure(err: unknown, debug: boolean, commandName?: string) {
     if (!(err instanceof Error)) {
         return;
     }
 
-    displayError(err);
+    displayError(err, commandName);
 
     if (debug) {
         console.log();
@@ -34,7 +34,7 @@ export function handleFailure(err: unknown, debug: boolean) {
     process.exit(1)
 }
 
-export function displayError(err: Error) {
+export function displayError(err: Error, commandName?: string) {
     switch (err.name) {
         case Unauthenticated.name: {
             print("To get started with Monokle, please run: monokle login")
@@ -66,8 +66,18 @@ export function displayError(err: Error) {
             return; // We just want to exit with process.exit(1)
         }
         default: {
-            print("Something unexpected happened, you can run with --debug for more details");
+            print(getFriendlyErrorMessage(err, commandName) ?? "Something unexpected happened, you can run with --debug for more details");
             return;
         }
     }
+}
+
+function getFriendlyErrorMessage(err: Error, commandName?: string): string | undefined {
+    const errMsg = err.message.toLowerCase().trim();
+
+    if (errMsg.startsWith('not found') && (commandName === "validate" || commandName === "config")) {
+        return "Error communicating with Monokle Cloud. Seems like used project id may be invalid, please make sure it's correct.";
+    }
+
+    return undefined;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -81,11 +81,11 @@ function getFriendlyErrorMessage(err: Error, argv: string[]): string {
 
     // Related to https://github.com/kubeshop/monokle-saas/issues/2173.
     if (errMsg.includes('cannot read properties of null') && errMsg.includes('organizationid')) {
-        return 'Error communicating with Monokle Cloud. Please make sure you are using valid Automation Token.';
+        return 'Cannot connect to Monokle Cloud. You might be using an invalid Automation Token.';
     }
 
     if (errMsg.startsWith('not found')) {
-        return 'Error communicating with Monokle Cloud. Seems like used project id may be invalid, please make sure it is correct.';
+        return 'Cannot connect to Monokle Cloud. You might be using an invalid project identifier.';
     }
 
     return 'Something unexpected happened.';


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle-saas/issues/2145.

## Changes

- Added dedicated error messages when invalid project id or automation token is provided.

This is not very generic approach, more targeted to this specific cases which were not handled earlier. I also reported related issue for Cloud API - https://github.com/kubeshop/monokle-saas/issues/2173. Seems like some of such errors should be handled closer to the core (like API itself or monokle-core) with dedicated error types which can be propagated and recognized by integrations.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
