### PR TITLE
fix: define version explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build:3": "chmod +x ./build/main.js",
     "prepackage": "rimraf build cjs dist && npm run build && npm run rollup",
     "test": "vitest run --test-timeout=10000",
-    "test:watch": "vitest --test-timeout=10000"
+    "test:watch": "vitest --test-timeout=10000",
+    "version": "node ./scripts/bump.js && git add src/version.ts"
   },
   "files": [
     "build"

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -1,0 +1,10 @@
+import { writeFileSync } from 'fs';
+import { join } from 'path'
+
+// This works only when run via npm.
+const version = process.env.npm_package_version;
+if (!version) {
+  throw new Error('No version found!');
+}
+
+writeFileSync(join(process.cwd(), 'src', 'version.ts'), `export const VERSION = '${version}';\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import { logout } from "./commands/logout.js";
 import { whoami } from "./commands/whoami.js";
 import { config } from "./commands/config.js";
 import { init } from "./commands/init.js";
-import {handleFailure} from "./errors.js";
+import { handleFailure } from "./errors.js";
+import { VERSION } from "./version.js";
 import fetch from "isomorphic-fetch";
 
 (global as any).fetch = fetch;
@@ -15,6 +16,7 @@ import "abortcontroller-polyfill/dist/polyfill-patch-fetch.js";
 const argv = hideBin(process.argv);
 export const cli = yargs(argv)
   .scriptName("monokle")
+  .version(VERSION)
   .parserConfiguration({
     "greedy-arrays": false,
   })

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = '0.7.2';


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle-saas/issues/1437.

## Changes

- None.

## Fixes

- Added dedicated file to store version so it is available no matter the package contents (see https://github.com/kubeshop/monokle-saas/issues/1437#issuecomment-1798431886). Bumping it is a part of release process now (where we use `npm version`).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
