### PR TITLE
Fix suppressions fetching when ApiKey used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@monokle/parser": "0.2.0",
-        "@monokle/synchronizer": "0.10.2",
-        "@monokle/types": "0.3.1",
-        "@monokle/validation": "0.31.5",
+        "@monokle/synchronizer": "^0.11.0",
+        "@monokle/types": "^0.3.2",
+        "@monokle/validation": "^0.31.6",
         "abortcontroller-polyfill": "1.7.5",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.10.2.tgz",
-      "integrity": "sha512-l5xmz3RSq95RFPBBck/I0DzazDvi1PxICEu+8tZmCs/8a9dyWZ0+LuB4Js2xCpTFaSc30gbuCwIDM2FXKgWoPw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.11.0.tgz",
+      "integrity": "sha512-S/FIi7CdfA63VGK+sfEGu1Kc1+BUaCX/L4LjaBfsO0gDzfMIHcXu//IcG0uphqqZUflaQ/2ahJCbPkd134Jlsw==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",
@@ -234,14 +234,14 @@
       }
     },
     "node_modules/@monokle/types": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@monokle/types/-/types-0.3.1.tgz",
-      "integrity": "sha512-IkbVrLOXZ38TZUfCYDp8XVVskvsLYftFb7ZXSn3PlxtIVbBVUIexqSm5erJ5ZK400f6yACCK+4qGzkPAJ43FVw=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@monokle/types/-/types-0.3.2.tgz",
+      "integrity": "sha512-z8ib9//zYCwQ0berVAxSOVClJxMIa5vveGyKMpqcEFJ5E9IDGVlYevV8PRExkq8vZ7FXBWCe8CeVwxxnYL+bXQ=="
     },
     "node_modules/@monokle/validation": {
-      "version": "0.31.5",
-      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.5.tgz",
-      "integrity": "sha512-Mp9pzNLt8+EE/xYJb/YbJiRFmIUnhP9hkFdo+5XhhhkmiFN3BhQauFkgSaSj6W/pEBSCzo7rYLxToKdRDED0iQ==",
+      "version": "0.31.6",
+      "resolved": "https://registry.npmjs.org/@monokle/validation/-/validation-0.31.6.tgz",
+      "integrity": "sha512-u825P4scKWbmpPTYxIUhUnSKKps505poU0j1JZlRDJ5TCO4bOIDVMZD1YEqwEYb9KtaTvYm6sN+l+mJiDvhtjA==",
       "dependencies": {
         "@monokle/types": "*",
         "@open-policy-agent/opa-wasm": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "log-symbols": "5.1.0",
         "open": "^9.1.0",
         "prompts": "^2.4.2",
+        "simple-git": "^3.20.0",
         "strands": "1.0.1",
         "tiny-glob": "0.2.9",
         "yaml": "2.1.1",
@@ -4664,9 +4665,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.19.1.tgz",
-      "integrity": "sha512-Ck+rcjVaE1HotraRAS8u/+xgTvToTuoMkT9/l9lvuP5jftwnYUp6DwuJzsKErHgfyRk8IB8pqGHWEbM3tLgV1w==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.20.0.tgz",
+      "integrity": "sha512-ozK8tl2hvLts8ijTs18iFruE+RoqmC/mqZhjs/+V7gS5W68JpJ3+FCTmLVqmR59MaUQ52MfGQuWsIqfsTbbJ0Q==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "log-symbols": "5.1.0",
     "open": "^9.1.0",
     "prompts": "^2.4.2",
+    "simple-git": "^3.20.0",
     "strands": "1.0.1",
     "tiny-glob": "0.2.9",
     "yaml": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   },
   "dependencies": {
     "@monokle/parser": "0.2.0",
-    "@monokle/synchronizer": "0.10.2",
-    "@monokle/types": "0.3.1",
-    "@monokle/validation": "0.31.5",
+    "@monokle/synchronizer": "^0.11.0",
+    "@monokle/types": "^0.3.2",
+    "@monokle/validation": "^0.31.6",
     "abortcontroller-polyfill": "1.7.5",
     "boxen": "7.0.0",
     "chalk": "5.0.1",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -48,7 +48,7 @@ export const config = command<Options>({
       })
       .option("origin", {
         type: "string",
-        description: "Monokle remote instance URL. Defaults to Monokle Cloud SaaS.",
+        description: "Monokle remote instance URL. Defaults to Monokle Cloud's origin.",
         alias: "r",
       })
       .positional("path", {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -5,6 +5,7 @@ import { Framework } from "../frameworks/index.js";
 import { getConfig } from "../utils/config.js";
 import { configInfo, configYaml, error } from "./config.io.js";
 import { assertApiFlags } from "../utils/flags.js";
+import { setOrigin } from "../utils/origin.js";
 
 type Options = {
   path: string;
@@ -13,6 +14,7 @@ type Options = {
   project?: string;
   framework?: Framework;
   'api-token'?: string;
+  origin?: string;
 };
 
 export const config = command<Options>({
@@ -44,13 +46,19 @@ export const config = command<Options>({
         description: "Monokle Cloud API token to fetch remote policy. It will be used instead of authenticated user credentials.",
         alias: "t",
       })
+      .option("origin", {
+        type: "string",
+        description: "Monokle remote instance URL. Defaults to Monokle Cloud SaaS.",
+        alias: "r",
+      })
       .positional("path", {
         type: "string",
         default: "."
       });
   },
-  async handler({ path, output, config, project, framework, apiToken }) {
+  async handler({ path, output, config, project, framework, apiToken, origin }) {
     assertApiFlags(apiToken, project);
+    setOrigin(origin);
 
     const configPath = config ?? 'monokle.validation.yaml';
     const isDefaultConfigPath = config === undefined;

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -16,6 +16,7 @@ import { getFingerprintSuppressions } from "../utils/getFingerprintSuppression.j
 import { ApiSuppression } from "@monokle/synchronizer";
 import { assertApiFlags } from "../utils/flags.js";
 import {InvalidArgument, NotFound, ValidationFailed} from "../errors.js";
+import { setOrigin } from "../utils/origin.js";
 
 type Options = {
   input: string;
@@ -27,7 +28,8 @@ type Options = {
   'api-token'?: string;
   'max-warnings': number;
   force: boolean;
-  'show-suppressed'?: boolean
+  'show-suppressed'?: boolean;
+  origin?: string;
 };
 
 export const validate = command<Options>({
@@ -83,10 +85,17 @@ export const validate = command<Options>({
         alias: "s",
         default: false
       })
+      .option("origin", {
+        type: "string",
+        description: "Monokle remote instance URL. Defaults to Monokle Cloud SaaS.",
+        alias: "r",
+      })
       .positional("input", { type: "string", description: "file/folder path or resource YAMLs via stdin", demandOption: true })
       .demandOption("input", "Path or stdin required for target resources");
   },
-  async handler({ input, output, project, config, inventory, framework, apiToken, maxWarnings, force, showSuppressed }) {
+  async handler({ input, output, project, config, inventory, framework, apiToken, maxWarnings, force, showSuppressed, origin }) {
+    setOrigin(origin);
+
     const files = await readFiles(input);
     const resources = extractK8sResources(files);
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -116,7 +116,7 @@ export const validate = command<Options>({
     const validator = createDefaultMonokleValidator();
     const [configData, suppressionsData] = await Promise.all([
       getConfig(input, configPath, project, framework, {isDefaultConfigPath, apiToken}),
-      getSuppressions(input, apiToken).catch(() => {
+      getSuppressions(input, project, apiToken).catch(() => {
         // continue with no suppressions
         return { suppressions: []} as { suppressions: ApiSuppression[]}
       })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ import { synchronizerGetter } from "./synchronizer.js";
 import { resolve } from "path";
 import { Framework, getFrameworkConfig } from "../frameworks/index.js";
 import { isStdinLike } from "./stdin.js";
+import { setOrigin } from "./origin.js";
 
 export type ConfigData = {
   config: Config | undefined,
@@ -65,6 +66,8 @@ export async function getConfig(
 
   const authenticator = authenticatorGetter.authenticator;
   if (!options.apiToken && authenticator.user.isAuthenticated) {
+    // Reset origin when device flow was used, since this is not supported yet.
+    setOrigin(undefined);
     await authenticator.refreshToken();
   }
 

--- a/src/utils/gitResourcesMapper.ts
+++ b/src/utils/gitResourcesMapper.ts
@@ -1,0 +1,185 @@
+import { dirname, relative, resolve } from "path";
+import { simpleGit, CheckRepoActions, SimpleGit } from "simple-git";
+import { Resource } from "@monokle/parser";
+import { ValidationResponse } from "@monokle/validation";
+
+export type Paths = {
+  new: string;
+  old: string;
+};
+
+export class GitResourceMapper {
+  protected resourcePathsMap: Map<string, Paths> = new Map(); // <resource.id, Paths>
+  protected mappedResources: Resource[] = [];
+
+  constructor(
+    protected resources: Resource[]
+  ) { }
+
+  async mapResourcePathsToRepoRootRelative() {
+    if (this.mappedResources.length > 0) {
+      return this.mappedResources;
+    }
+
+    const gitInstances: Map<string, SimpleGit> = new Map();
+
+    for (const resource of this.resources) {
+      const resourcePath = resource.filePath;
+      const resourceDir = dirname(resourcePath);
+      const fullResourcePath = resolve(resourcePath);
+      const fullResourceDir = resolve(resourceDir);
+
+      const git = gitInstances.get(fullResourceDir) || simpleGit(fullResourceDir);
+      gitInstances.set(fullResourceDir, git);
+
+      const isGitRepo = await git.checkIsRepo();
+      if (!isGitRepo) {
+        this.mappedResources.push(resource);
+        continue;
+      }
+
+      const isGitRepoRoot = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+
+      let repoRootFull = fullResourceDir;
+      if (!isGitRepoRoot) {
+        const gitRoot = await git.revparse(["--show-toplevel"]);
+        repoRootFull = resolve(gitRoot);
+      }
+
+      const relativePath = relative(repoRootFull, fullResourcePath);
+
+      const mappedResource = {
+        ...resource,
+        filePath: relativePath,
+      }
+
+      this.resourcePathsMap.set(resource.id, {
+        new: relativePath,
+        old: resourcePath,
+      });
+
+      this.mappedResources.push(mappedResource);
+    }
+
+    return this.mappedResources;
+  }
+
+  restoreInitialResourcePaths(validationResponse: ValidationResponse) {
+    validationResponse.runs.forEach(run => {
+      run.results.forEach(result => {
+        const resourceLocationWithId = result.locations.find(location => location.physicalLocation?.artifactLocation?.uriBaseId === 'RESOURCE');
+        const resourceId = resourceLocationWithId?.physicalLocation?.artifactLocation?.uri;
+        const resourcePaths = this.resourcePathsMap.get(resourceId || '');
+
+        if (resourcePaths) {
+          const srcRootLocation = result.locations.find(location => location.physicalLocation?.artifactLocation?.uriBaseId === 'SRCROOT');
+          if (srcRootLocation) {
+            srcRootLocation.physicalLocation!.artifactLocation.uri = resourcePaths.old;
+          }
+
+          const resourceLogicalLocation = result.locations.find(location => location.logicalLocations?.find(locationPart => locationPart.kind === 'resource'));
+          const resourceLogicalLocationObj = resourceLogicalLocation?.logicalLocations!.find(locationPart => locationPart.kind === 'resource');
+          const newFullyQualifiedName = resourceLogicalLocationObj?.fullyQualifiedName;
+          if (newFullyQualifiedName) {
+            resourceLogicalLocationObj.fullyQualifiedName = resourceLogicalLocationObj.fullyQualifiedName?.replace(
+              new RegExp(`${resourcePaths.new}$`),
+              resourcePaths.old
+            );
+          }
+        }
+      });
+    });
+
+    return validationResponse;
+  }
+}
+
+// Location references so it is easier to grasp what GitResourceMapper.restoreInitialResourcePaths() does:
+//
+// With repo root relative paths:
+// "locations": [
+//   {
+//     "physicalLocation": {
+//       "artifactLocation": {
+//         "uriBaseId": "SRCROOT",
+//         "uri": "standalone/deployment.yaml"
+//       },
+//       "region": {
+//         "startLine": 23,
+//         "startColumn": 18,
+//         "endLine": 23,
+//         "endColumn": 35
+//       }
+//     }
+//   },
+//   {
+//     "physicalLocation": {
+//       "artifactLocation": {
+//         "uriBaseId": "RESOURCE",
+//         "uri": "3e1520dd-1689-505b-8894-f481b0a234ef"
+//       },
+//       "region": {
+//         "startLine": 23,
+//         "startColumn": 18,
+//         "endLine": 23,
+//         "endColumn": 35
+//       }
+//     },
+//     "logicalLocations": [
+//       {
+//         "kind": "resource",
+//         "fullyQualifiedName": "panda-blog.third-branch.deployment@standalone/deployment.yaml",
+//         "name": "panda-blog"
+//       },
+//       {
+//         "kind": "element",
+//         "name": "image",
+//         "fullyQualifiedName": "spec.template.spec.containers.0.image"
+//       }
+//     ]
+//   }
+// ]
+//
+// With paths relative to how CLI command was run:
+// "locations": [
+//   {
+//     "physicalLocation": {
+//       "artifactLocation": {
+//         "uriBaseId": "SRCROOT",
+//         "uri": "../monokle-demo/standalone/deployment.yaml"
+//       },
+//       "region": {
+//         "startLine": 23,
+//         "startColumn": 18,
+//         "endLine": 23,
+//         "endColumn": 35
+//       }
+//     }
+//   },
+//   {
+//     "physicalLocation": {
+//       "artifactLocation": {
+//         "uriBaseId": "RESOURCE",
+//         "uri": "3e1520dd-1689-505b-8894-f481b0a234ef"
+//       },
+//       "region": {
+//         "startLine": 23,
+//         "startColumn": 18,
+//         "endLine": 23,
+//         "endColumn": 35
+//       }
+//     },
+//     "logicalLocations": [
+//       {
+//         "kind": "resource",
+//         "fullyQualifiedName": "panda-blog.third-branch.deployment@../monokle-demo/standalone/deployment.yaml",
+//         "name": "panda-blog"
+//       },
+//       {
+//         "kind": "element",
+//         "name": "image",
+//         "fullyQualifiedName": "spec.template.spec.containers.0.image"
+//       }
+//     ]
+//   }
+// ]

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,0 +1,11 @@
+let origin: string | undefined = undefined;
+
+export function setOrigin(originFlag?: string) {
+  if (originFlag) {
+    origin = originFlag;
+  }
+}
+
+export function getOrigin() {
+  return origin || process.env.MONOKLE_ORIGIN;
+}

--- a/src/utils/suppressions.ts
+++ b/src/utils/suppressions.ts
@@ -2,6 +2,7 @@ import {  Suppression, } from "@monokle/validation";
 import { TokenInfo } from "@monokle/synchronizer";
 import { authenticatorGetter } from "./authenticator.js";
 import { synchronizerGetter } from "./synchronizer.js";
+import { setOrigin } from "./origin.js";
 
 export type SuppressionsData = {
   suppressions: Suppression[],
@@ -22,6 +23,8 @@ export async function getSuppressions(
   const authenticator = authenticatorGetter.authenticator;
 
   if (!apiToken && authenticator.user.isAuthenticated) {
+    // Reset origin when device flow was used, since this is not supported yet.
+    setOrigin(undefined);
     await authenticator.refreshToken();
   }
 

--- a/src/utils/suppressions.ts
+++ b/src/utils/suppressions.ts
@@ -16,7 +16,8 @@ export type SuppressionsData = {
  */
 export async function getSuppressions(
   path: string,
-  apiToken: string | undefined
+  projectSlug: string | undefined,
+  apiToken: string | undefined,
 ) {
   const authenticator = authenticatorGetter.authenticator;
 
@@ -34,10 +35,9 @@ export async function getSuppressions(
   const synchronizer = synchronizerGetter.synchronizer
 
   try {
-    return { suppressions:  await synchronizer.getSuppressions(path, tokenInfo)}
+    return { suppressions: await synchronizer.getSuppressions({ path, ownerProjectSlug: projectSlug }, tokenInfo)}
   } catch (err){
     // continue with no suppressions
+    return { suppressions: [] }
   }
-  return { suppressions: [] }
-
 }

--- a/src/utils/synchronizer.ts
+++ b/src/utils/synchronizer.ts
@@ -1,15 +1,20 @@
-import { createDefaultMonokleSynchronizer, Synchronizer} from "@monokle/synchronizer";
+import { ApiHandler, createDefaultMonokleSynchronizer, StorageHandlerPolicy, Synchronizer} from "@monokle/synchronizer";
+import { getOrigin } from "./origin.js";
 
 // This class exists for test purposes to easily mock the synchronizer.
 // It also ensures singleton instance of the synchronizer is used.
 class SynchronizerGetter {
-  private _synchronizer: Synchronizer;
+  private _synchronizer: Synchronizer | undefined = undefined;
 
-  constructor() {
-    this._synchronizer = createDefaultMonokleSynchronizer();
-  }
+  get synchronizer(): Synchronizer {
+    // Lazy create synchronizer so initial configuration (like origin) can be set by other parts of the code.
+    if (!this._synchronizer) {
+      this._synchronizer = createDefaultMonokleSynchronizer(
+        new StorageHandlerPolicy(),
+        new ApiHandler(getOrigin())
+      );
+    }
 
-  get synchronizer() {
     return this._synchronizer;
   }
 }


### PR DESCRIPTION
This PR fixes how suppressions are fetched. Most work was done in external deps - to work, this PR requires both:

- https://github.com/kubeshop/monokle-core/pull/564 (and CI will fails unless this is merged and updated as dep here)
- https://github.com/kubeshop/monokle-saas/pull/2185

To be merged (and deployed).

Fixes https://github.com/kubeshop/monokle-saas/issues/2037.

## Changes

- Add `--origin` param to `validate` and `config` commands as mentioned in #23 (needed it for testing and since it was a small change I added it).

## Fixes

- Fixed how suppressions are fetched from API.
- Added resource paths mapping to be repo root relative for the time of validation. This makes fingerprints to match no matter how the resources path is passed to `validate` command - see https://github.com/kubeshop/monokle-saas/issues/2037#issuecomment-1805534727 for more details.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
