### PR TITLE
Use origin to fetch schema loader URL for validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@monokle/parser": "0.2.0",
-        "@monokle/synchronizer": "^0.12.2",
+        "@monokle/synchronizer": "^0.12.3",
         "@monokle/types": "^0.3.2",
         "@monokle/validation": "^0.31.7",
         "abortcontroller-polyfill": "1.7.5",
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.2.tgz",
-      "integrity": "sha512-HUFtQmwYcbLQEwfuomWEEU199E/mz8/Xia9BVlPIq/gbWqsxcSHe0fmonNTOuzW8bBGcst376OPuYY/eG2/SWg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.3.tgz",
+      "integrity": "sha512-2B9Gdw31v5c3GqIuTfMqTA9nJnwj8jne7+LiiDpQ7B6FOy94UXEuh78H+DTRAO2jReW3NPFV4wBPgFgakiZQGw==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@monokle/parser": "0.2.0",
-    "@monokle/synchronizer": "^0.12.2",
+    "@monokle/synchronizer": "^0.12.3",
     "@monokle/types": "^0.3.2",
     "@monokle/validation": "^0.31.7",
     "abortcontroller-polyfill": "1.7.5",

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,9 +1,11 @@
-import {  createDefaultMonokleValidator, processRefs, ResourceParser } from "@monokle/validation";
-import { extractK8sResources, BaseFile } from "@monokle/parser";
 import { lstatSync } from "fs";
 import { readFile as readFileFromFs } from "fs/promises";
 import chunkArray from "lodash/chunk.js";
 import glob from "tiny-glob";
+import { extractK8sResources, BaseFile } from "@monokle/parser";
+import { ResourceParser, processRefs } from "@monokle/validation";
+import { ApiSuppression } from "@monokle/synchronizer";
+import { validatorGetter } from "../utils/validator.js";
 import { command } from "../utils/command.js";
 import { print } from "../utils/screens.js";
 import { isStdinLike, streamToPromise } from "../utils/stdin.js";
@@ -13,7 +15,6 @@ import { Framework } from "../frameworks/index.js";
 import { getSuppressions } from "../utils/suppressions.js";
 import { getValidationResponseBreakdown } from "../utils/getValidationResponseBreakdown.js";
 import { getFingerprintSuppressions } from "../utils/getFingerprintSuppression.js";
-import { ApiSuppression } from "@monokle/synchronizer";
 import { assertFlags } from "../utils/flags.js";
 import { InvalidArgument, NotFound, ValidationFailed} from "../errors.js";
 import { GitResourceMapper } from "../utils/gitResourcesMapper.js";
@@ -133,7 +134,7 @@ export const validate = command<Options>({
     const isDefaultConfigPath = config === undefined;
 
     const parser = new ResourceParser();
-    const validator = createDefaultMonokleValidator();
+    const validator = await validatorGetter.getInstance();
     const [configData, suppressionsData] = await Promise.all([
       getConfig(input, configPath, project, framework, {isDefaultConfigPath, apiToken}),
       getSuppressions(input, project, apiToken).catch(() => {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,44 @@
+import { ResourceParser, MonokleValidator, RemotePluginLoader, requireFromStringCustomPluginLoader, SchemaLoader, AnnotationSuppressor, FingerprintSuppressor, DisabledFixer } from "@monokle/validation";
+import { fetchOriginConfig } from "@monokle/synchronizer";
+import { settings } from "./settings.js";
+
+// This class exists for test purposes to easily mock the validator.
+// It also ensures singleton instance of the synchronizer is used.
+class ValidatorGetter {
+  private _validator: MonokleValidator | undefined = undefined;
+
+  async getInstance(): Promise<MonokleValidator> {
+    // Lazy create Validator so initial configuration (like origin) can be set by other parts of the code.
+    if (!this._validator) {
+      const origin = settings.origin;
+
+      try {
+        const originConfig = await fetchOriginConfig(origin);
+        this._validator = new MonokleValidator(
+            {
+              loader: new RemotePluginLoader(requireFromStringCustomPluginLoader),
+              parser: new ResourceParser(),
+              schemaLoader: new SchemaLoader(originConfig.schemasOrigin || undefined),
+              suppressors: [new AnnotationSuppressor(), new FingerprintSuppressor()],
+              fixer: new DisabledFixer(),
+            },
+            {
+              plugins: {
+                'kubernetes-schema': true,
+                'yaml-syntax': true,
+                'pod-security-standards': true,
+                'resource-links': true,
+              },
+            }
+          );
+      } catch (err) {
+        // If we can't use given origin, it doesn't make sense to continue.
+        throw err;
+      }
+    }
+
+    return this._validator;
+  }
+}
+
+export const validatorGetter = new ValidatorGetter();


### PR DESCRIPTION
This PR fixes how validator is initialized to take into account dynamic schema store origin. Part of https://github.com/kubeshop/monokle-saas/issues/2212.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
