### PR TITLE
fix: handle origin connection issues without throwing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,12 +8,17 @@ import { config } from "./commands/config.js";
 import { init } from "./commands/init.js";
 import { handleFailure } from "./errors.js";
 import { VERSION } from "./version.js";
+import { settings } from "./utils/settings.js";
 import fetch from "isomorphic-fetch";
 
 (global as any).fetch = fetch;
 import "abortcontroller-polyfill/dist/polyfill-patch-fetch.js";
 
 const argv = hideBin(process.argv);
+const debug = argv.includes("--debug");
+
+settings.debug = debug;
+
 export const cli = yargs(argv)
   .scriptName("monokle")
   .version(VERSION)
@@ -33,7 +38,6 @@ export const cli = yargs(argv)
       "Learn more at https://github.com/kubeshop/monokle-cli");
   })
   .fail((_, err) => {
-    const debug = argv.includes("--debug");
     handleFailure(err, debug, argv);
   })
   .showHelpOnFail(false)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,6 +72,10 @@ export function displayError(err: Error, argv: string[]) {
     }
 }
 
+export function displayWarning(msg: string) {
+    print(warningInfo(msg));
+}
+
 function getFriendlyErrorMessage(err: Error, argv: string[]): string {
     if (!isApiTokenUsed(argv) || !isCloudCommand(argv)) {
         return 'Something unexpected happened.';

--- a/src/utils/authenticator.ts
+++ b/src/utils/authenticator.ts
@@ -24,12 +24,20 @@ class AuthenticatorGetter {
       try {
         this._authenticator = await createMonokleAuthenticatorFromOrigin(AUTHENTICATOR_CLIENT_ID, origin || undefined);
       } catch (err) {
-        // If we can't use given origin, it doesn't make sense to continue.
+        // If we can't use given origin, it doesn't make sense to continue since it's not possible to authenticate then.
         throw err;
       }
     }
 
     return this._authenticator;
+  }
+
+  async getInstanceSafe(recreate = false): Promise<Authenticator | undefined> {
+    try {
+      return await this.getInstance(recreate);
+    } catch (err) {
+      return undefined;
+    }
   }
 }
 

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -2,7 +2,7 @@ import { authenticatorGetter } from "./authenticator.js";
 import {AlreadyAuthenticated, Unauthenticated} from "../errors.js";
 
 export async function isAuthenticated() {
-  return Boolean((await authenticatorGetter.getInstance()).user.isAuthenticated);
+  return Boolean((await authenticatorGetter.getInstanceSafe())?.user.isAuthenticated);
 }
 
 export async function throwIfNotAuthenticated() {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -6,9 +6,14 @@ export type Settings = {
   origin?: string;
 };
 
+export type EphemeralSettings = {
+  debug?: boolean;
+};
+
 export class StorageSettings extends StorageHandler<Settings> {
   private currentData: Settings = {};
   private initialData: Settings = {};
+  private ephemeralData: EphemeralSettings = {};
 
   constructor() {
     super(getDefaultStorageConfigPaths().config);
@@ -25,6 +30,14 @@ export class StorageSettings extends StorageHandler<Settings> {
 
   set origin(origin: string) {
     this.currentData.origin = origin;
+  }
+
+  get debug() {
+    return this.ephemeralData.debug || false;
+  }
+
+  set debug(debug: boolean) {
+    this.ephemeralData.debug = debug;
   }
 
   async persist() {

--- a/src/utils/synchronizer.ts
+++ b/src/utils/synchronizer.ts
@@ -14,7 +14,7 @@ class SynchronizerGetter {
       try {
         this._synchronizer = await createMonokleSynchronizerFromOrigin(origin || undefined);
       } catch (err) {
-        // If we can't use given origin, it doesn't make sense to continue.
+        // If we can't use given origin, it doesn't make sense to continue since it's not possible to synchronize policies then.
         throw err;
       }
     }

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,6 +1,7 @@
 import { ResourceParser, MonokleValidator, RemotePluginLoader, requireFromStringCustomPluginLoader, SchemaLoader, AnnotationSuppressor, FingerprintSuppressor, DisabledFixer } from "@monokle/validation";
 import { fetchOriginConfig } from "@monokle/synchronizer";
 import { settings } from "./settings.js";
+import { displayWarning } from "../errors.js";
 
 // This class exists for test purposes to easily mock the validator.
 // It also ensures singleton instance of the synchronizer is used.
@@ -12,29 +13,33 @@ class ValidatorGetter {
     if (!this._validator) {
       const origin = settings.origin;
 
+      let schemasOrigin: string | undefined = undefined;
       try {
         const originConfig = await fetchOriginConfig(origin);
-        this._validator = new MonokleValidator(
-            {
-              loader: new RemotePluginLoader(requireFromStringCustomPluginLoader),
-              parser: new ResourceParser(),
-              schemaLoader: new SchemaLoader(originConfig.schemasOrigin || undefined),
-              suppressors: [new AnnotationSuppressor(), new FingerprintSuppressor()],
-              fixer: new DisabledFixer(),
-            },
-            {
-              plugins: {
-                'kubernetes-schema': true,
-                'yaml-syntax': true,
-                'pod-security-standards': true,
-                'resource-links': true,
-              },
-            }
-          );
-      } catch (err) {
-        // If we can't use given origin, it doesn't make sense to continue.
-        throw err;
+        schemasOrigin = originConfig?.schemasOrigin;
+      } catch (err: any) {
+        if (settings.debug) {
+          displayWarning(`Could not connect to origin: ${origin}. Using default schemas for validation. Error: ${err.message}.`);
+        }
       }
+
+      this._validator = new MonokleValidator(
+        {
+          loader: new RemotePluginLoader(requireFromStringCustomPluginLoader),
+          parser: new ResourceParser(),
+          schemaLoader: new SchemaLoader(schemasOrigin),
+          suppressors: [new AnnotationSuppressor(), new FingerprintSuppressor()],
+          fixer: new DisabledFixer(),
+        },
+        {
+          plugins: {
+            'kubernetes-schema': true,
+            'yaml-syntax': true,
+            'pod-security-standards': true,
+            'resource-links': true,
+          },
+        }
+      );
     }
 
     return this._validator;


### PR DESCRIPTION
This PR fixes issue where CLI would error when origin cannot be reached.

This is mostly related to policy config synchronization and:

1. It makes sense to catch such errors for `validate` and `config` commands where we can fallback to local config.
    - The command will run fine. When `--debug` flag is provided it will additionally display warning with error message (if there is one). This is because it needs to be debug-able and users should be able to see the reason why local config was used as fallback.
2. For auth related commands the behavior is the same as before since without connecting to origin, those can't basically run. The only addition is that `isAuthenticated` check will not throw when origin cannot be reached, just return false - this makes the correct error to be shown while those commands fail.

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
